### PR TITLE
수출 규정 관련 문서 위치를 수정했어요

### DIFF
--- a/dogether/Info.plist
+++ b/dogether/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>
@@ -16,8 +18,6 @@
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
-		<key>ITSAppUsesNonExemptEncryption</key>
-		<false/>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 		<key>UISceneConfigurations</key>


### PR DESCRIPTION
### 🔧 변경 사항
- 수출 규정 관련 설정을 수정했어요

###  🔍 변경 이유
- 수출 규정 관련 설정을 실수로 UIApplicationSceneManifest 아래에 두었었네요 테스터 초대용으로 TestFlight에 앱을 올렸는데 적용이 안되어있는 걸 보고 수정했습니다