### PR TITLE
투두 검사 화면을 구현했어요

### DIFF
--- a/dogether/Domain/Entity/PopupTypes.swift
+++ b/dogether/Domain/Entity/PopupTypes.swift
@@ -10,4 +10,5 @@ import Foundation
 enum PopupTypes {
     case certification
     case certificationInfo
+    case rejectReason
 }

--- a/dogether/Presentation/Common/CertificationPopupView.swift
+++ b/dogether/Presentation/Common/CertificationPopupView.swift
@@ -16,9 +16,9 @@ final class CertificationPopupView: UIView {
     private let certificationMaxLength = 20
     
     // TODO: 추후 수정
-    private var completeAction: () -> Void
+    private var completeAction: (String) -> Void
     
-    init(completeAction: @escaping () -> Void) {
+    init(completeAction: @escaping (String) -> Void) {
         self.completeAction = completeAction
         super.init(frame: .zero)
         setUI()
@@ -119,18 +119,18 @@ final class CertificationPopupView: UIView {
         label.textColor = .grey400
         label.font = Fonts.body2S
         
-        [imageView, label].forEach { view.addSubview($0) }
+        let stackView = UIStackView(arrangedSubviews: [imageView, label])
+        stackView.axis = .horizontal
+        stackView.spacing = 8
         
-        imageView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.left.equalTo(45)
-            $0.width.height.equalTo(24)
+        [stackView].forEach { view.addSubview($0) }
+        
+        stackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
         
-        label.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.left.equalTo(imageView.snp.right).offset(8)
-            $0.height.equalTo(21)
+        imageView.snp.makeConstraints {
+            $0.width.height.equalTo(24)
         }
         
         return view
@@ -289,8 +289,8 @@ final class CertificationPopupView: UIView {
         certificationTextView.becomeFirstResponder()
         certificationMaxLengthLabel.text = "/\(certificationMaxLength)"
         certificationButton = DogetherButton(action: {
+            self.completeAction(self.certificationTextView.text)
             PopupManager.shared.hidePopup()
-            self.completeAction()
         }, title: "인증하기", status: .enabled)
         
         [
@@ -384,14 +384,15 @@ extension CertificationPopupView: UITextViewDelegate {
     
     // MARK: - UITextFieldDelegate
     @objc private func keyboardWillShow(_ notification: Notification) {
-        if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
-            let keyboardHeight = keyboardFrame.height
-            self.snp.updateConstraints { $0.centerY.equalToSuperview().offset(-keyboardHeight / 2) }
-            UIView.animate(withDuration: 0.3) { self.layoutIfNeeded() }
-        }
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+                 let superview = self.superview else { return }
+        let keyboardHeight = keyboardFrame.height
+        self.snp.updateConstraints { $0.centerY.equalToSuperview().offset(-keyboardHeight / 2) }
+        UIView.animate(withDuration: 0.3) { self.layoutIfNeeded() }
     }
     
     @objc private func keyboardWillHide(_ notification: Notification) {
+        guard let superview = self.superview else { return }
         self.snp.updateConstraints { $0.centerY.equalToSuperview() }
         UIView.animate(withDuration: 0.3) { self.layoutIfNeeded() }
     }

--- a/dogether/Presentation/Common/ExaminationModalityView.swift
+++ b/dogether/Presentation/Common/ExaminationModalityView.swift
@@ -1,0 +1,137 @@
+//
+//  ExaminationModalityView.swift
+//  dogether
+//
+//  Created by seungyooooong on 2/17/25.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+
+final class ExaminationModalityView: UIView {
+    var buttonAction: (FilterTypes) -> Void
+    private var todoInfo: TodoInfo
+    
+    init(buttonAction: @escaping (FilterTypes) -> Void, todoInfo: TodoInfo) {
+        self.buttonAction = buttonAction
+        self.todoInfo = todoInfo
+        super.init(frame: .zero)
+        setUI()
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    
+    private var imageView = UIImageView()
+    
+    private let contentLabel = {
+        let label = UILabel()
+        label.textColor = .grey0
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    private func examinationButton(type: FilterTypes) -> UIButton {
+        let button = UIButton()
+        button.backgroundColor = .grey0
+        button.layer.cornerRadius = 8
+        button.tag = type.tag
+        button.addTarget(self, action: #selector(didTapExaminationButton(_:)), for: .touchUpInside)
+        
+        let icon = UIImageView(image: type.image?.withRenderingMode(.alwaysTemplate))
+        icon.tintColor = .grey700
+        
+        let label = UILabel()
+        label.text = type.rawValue
+        label.textColor = .grey700
+        label.font = Fonts.body1S
+        
+        let stackView = UIStackView(arrangedSubviews: [icon, label])
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        stackView.isUserInteractionEnabled = false
+        
+        [stackView].forEach { button.addSubview($0) }
+        
+        stackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        icon.snp.makeConstraints {
+            $0.width.height.equalTo(type == .reject ? 22 : 24)    // MARK: 임의로 사이즈 조정
+        }
+        
+        return button
+    }
+    private var rejectButton = UIButton()
+    private var approveButton = UIButton()
+    
+    private func examinationStackView(buttons: [UIButton]) -> UIStackView {
+        let stackView = UIStackView(arrangedSubviews: buttons)
+        stackView.axis = .horizontal
+        stackView.spacing = 11
+        stackView.distribution = .fillEqually
+        return stackView
+    }
+    private var examinationStackView = UIStackView()
+    
+    private func setUI() {
+        backgroundColor = .grey800
+        layer.cornerRadius = 12
+        
+        // TODO: 추후 수정
+        imageView = CertificationImageView(
+            image: .logo,
+            todoContent: todoInfo.todoContent ?? "",
+            certificator: UserDefaultsManager.shared.userFullName ?? ""
+        )
+        
+        contentLabel.attributedText = NSAttributedString(
+            string: todoInfo.content,
+            attributes: Fonts.getAttributes(for: Fonts.head2B, textAlignment: .center)
+        )
+        
+        rejectButton = examinationButton(type: .reject)
+        approveButton = examinationButton(type: .approve)
+        examinationStackView = examinationStackView(buttons: [rejectButton, approveButton])
+        
+        [imageView, contentLabel, examinationStackView].forEach { addSubview($0) }
+        
+        self.snp.updateConstraints {
+            $0.height.equalTo(487)
+        }
+        
+        imageView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(24)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(303)
+        }
+        
+        contentLabel.snp.makeConstraints {
+            $0.top.equalTo(imageView.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(56)
+        }
+        
+        examinationStackView.snp.makeConstraints {
+            $0.top.equalTo(contentLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(48)
+        }
+    }
+    
+    @objc private func didTapExaminationButton(_ sender: UIButton) {
+        guard let type = FilterTypes.allCases.first(where: { $0.tag == sender.tag }) else { return }
+        
+        rejectButton.backgroundColor = type == .reject ? .dogetherRed : .grey0
+        approveButton.backgroundColor = type == .approve ? .blue300 : .grey0
+        
+        switch type {
+        case .reject:
+            buttonAction(type)
+        case .approve:
+            buttonAction(type)
+        default:
+            return
+        }
+    }
+}

--- a/dogether/Presentation/Common/RejectReasonPopupView.swift
+++ b/dogether/Presentation/Common/RejectReasonPopupView.swift
@@ -1,0 +1,253 @@
+//
+//  RejectReasonPopupView.swift
+//  dogether
+//
+//  Created by seungyooooong on 2/17/25.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+
+final class RejectReasonPopupView: UIView {
+    private let rejectReasonMaxLength = 60
+    
+    private var completeAction: (String) -> Void
+    
+    init(completeAction: @escaping (String) -> Void) {
+        self.completeAction = completeAction
+        super.init(frame: .zero)
+        setUI()
+        setupKeyboardHandling()
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    
+    private let closeButton = {
+        let button = UIButton()
+        button.setImage(.close.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.tintColor = .grey0
+        return button
+    }()
+    
+    private let descriptionLabel = {
+        let label = UILabel()
+        label.text = "이유를 들려주세요 !"
+        label.textColor = .grey0
+        label.textAlignment = .center
+        label.font = Fonts.head1B
+        return label
+    }()
+    
+    private func descriptionView(tempParameter: Bool = false) -> UIView {
+        let view = UIView()
+        view.layer.cornerRadius = 8
+        view.layer.borderColor = UIColor.grey600.cgColor
+        view.layer.borderWidth = 1
+        
+        let imageView = UIImageView(image: .notice)
+        
+        let label = UILabel()
+        label.text = "한번 등록한 피드백은 바꿀 수 없어요"
+        label.textColor = .grey400
+        label.font = Fonts.body2S
+        
+        let stackView = UIStackView(arrangedSubviews: [imageView, label])
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        
+        [stackView].forEach { view.addSubview($0) }
+        
+        stackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        imageView.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+        }
+        
+        return view
+    }
+    private var descriptionView = UIView()
+    
+    private let rejectReasonView = {
+        let view = UIView()
+        view.backgroundColor = .grey800
+        view.layer.cornerRadius = 12
+        view.layer.borderColor = UIColor.blue300.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+    
+    private let rejectReasonPlaceHolder = {
+        let label = UILabel()
+        label.textColor = .grey300
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        return label
+    }()
+    
+    private func rejectReasonTextView(tempParameter: Bool = false) -> UITextView {
+        let textView = UITextView()
+        textView.text = ""
+        textView.textColor = .grey50
+        textView.font = Fonts.body1R
+        textView.tintColor = .blue300
+        textView.backgroundColor = .clear
+        textView.textContainer.lineFragmentPadding = 0
+        textView.textContainerInset = .zero
+        textView.delegate = self
+        return textView
+    }
+    private var rejectReasonTextView = UITextView()
+    
+    private let rejectReasonTextCountLabel = {
+        let label = UILabel()
+        label.text = "0"
+        label.textColor = .blue300
+        label.font = Fonts.smallS
+        return label
+    }()
+    
+    private let rejectReasonMaxLengthLabel = {
+        let label = UILabel()
+        label.textColor = .grey400
+        label.font = Fonts.smallS
+        return label
+    }()
+    
+    private var rejectReasonButton = DogetherButton(action: { }, title: "등록하기", status: .disabled)
+    
+    private func setUI() {
+        backgroundColor = .grey700
+        layer.cornerRadius = 12
+        
+        closeButton.addTarget(self, action: #selector(didTapCloseButton), for: .touchUpInside)
+        
+        descriptionView = descriptionView()
+        rejectReasonPlaceHolder.attributedText = NSAttributedString(
+            string: "팀원이 이해하기 쉽도록 인증에 대한 설명을 입력하세요.",
+            attributes: Fonts.getAttributes(for: Fonts.body1R, textAlignment: .left)
+        )
+        rejectReasonTextView = rejectReasonTextView()
+        rejectReasonTextView.becomeFirstResponder()
+        rejectReasonMaxLengthLabel.text = "/\(rejectReasonMaxLength)"
+        rejectReasonButton = DogetherButton(action: {
+            self.completeAction(self.rejectReasonTextView.text)
+            PopupManager.shared.hidePopup()
+        }, title: "등록하기", status: .disabled)
+        
+        [
+            closeButton, descriptionLabel, descriptionView,
+            rejectReasonView, rejectReasonPlaceHolder, rejectReasonTextView,
+            rejectReasonTextCountLabel, rejectReasonMaxLengthLabel,
+            rejectReasonButton
+        ].forEach { addSubview($0) }
+        
+        self.snp.updateConstraints {
+            $0.height.equalTo(422)
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(24)
+            $0.right.equalToSuperview().offset(-20)
+            $0.width.height.equalTo(24)
+        }
+        
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(closeButton.snp.bottom).offset(8)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(36)
+        }
+        
+        descriptionView.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(8)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(40)
+        }
+        
+        rejectReasonView.snp.makeConstraints {
+            $0.top.equalTo(descriptionView.snp.bottom).offset(24)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(160)
+        }
+        
+        rejectReasonPlaceHolder.snp.makeConstraints {
+            $0.top.equalTo(rejectReasonView).offset(16)
+            $0.horizontalEdges.equalTo(rejectReasonView).inset(16)
+            $0.width.equalTo(271)
+        }
+        
+        rejectReasonTextView.snp.makeConstraints {
+            $0.top.equalTo(rejectReasonView).offset(22)
+            $0.horizontalEdges.equalTo(rejectReasonView).inset(16)
+            $0.width.equalTo(271)
+            $0.height.equalTo(100)
+        }
+        
+        rejectReasonTextCountLabel.snp.makeConstraints {
+            $0.bottom.equalTo(rejectReasonView).inset(16)
+            $0.right.equalTo(rejectReasonMaxLengthLabel.snp.left)
+            $0.height.equalTo(18)
+        }
+        
+        rejectReasonMaxLengthLabel.snp.makeConstraints {
+            $0.bottom.equalTo(rejectReasonView).inset(16)
+            $0.right.equalTo(rejectReasonView).inset(16)
+            $0.height.equalTo(18)
+        }
+        
+        rejectReasonButton.snp.makeConstraints {
+            $0.top.equalTo(rejectReasonView.snp.bottom).offset(20)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(50)
+        }
+    }
+    
+    @objc private func didTapCloseButton() {
+        PopupManager.shared.hidePopup()
+    }
+}
+
+// MARK: - abount keyboard
+extension RejectReasonPopupView: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        if let text = textView.text {
+            if text.count > rejectReasonMaxLength {
+                textView.text = String(text.prefix(rejectReasonMaxLength))
+            }
+            rejectReasonPlaceHolder.isHidden = text.count > 0
+            rejectReasonTextCountLabel.text = String(textView.text.count)
+            rejectReasonButton.setButtonStatus(status: text.count > 0 ? .enabled : .disabled)
+        }
+    }
+    
+    private func setupKeyboardHandling() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    // MARK: - UITextFieldDelegate
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+                 let superview = self.superview else { return }
+        let keyboardHeight = keyboardFrame.height
+        self.snp.updateConstraints { $0.centerY.equalToSuperview().offset(-keyboardHeight / 2) }
+        UIView.animate(withDuration: 0.3) { self.layoutIfNeeded() }
+    }
+    
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        guard let superview = self.superview else { return }
+        self.snp.updateConstraints { $0.centerY.equalToSuperview() }
+        UIView.animate(withDuration: 0.3) { self.layoutIfNeeded() }
+    }
+}

--- a/dogether/Presentation/View/ModalityViewController.swift
+++ b/dogether/Presentation/View/ModalityViewController.swift
@@ -1,0 +1,95 @@
+//
+//  ModalityViewController.swift
+//  dogether
+//
+//  Created by seungyooooong on 2/17/25.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+
+final class ModalityViewController: BaseViewController {
+    // TODO: 현재는 TodoExamination 단일 종류만 존재하지만 추후 확장
+    private let backgroundView = {
+        let view = UIView()
+        view.backgroundColor = .grey900.withAlphaComponent(0.8)
+        return view
+    }()
+    
+    private let titlaLabel = {
+        let label = UILabel()
+        label.text = "투두를 검사해주세요!"
+        label.textColor = .grey0
+        label.font = Fonts.head1B
+        return label
+    }()
+    
+    private var todoExaminationModalityView = UIView()
+    
+    private var closeButton = DogetherButton(action: { }, title: "보내기", status: .disabled)
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func configureView() {
+        // TODO: 추후 수정
+        let todoInfos = [
+            TodoInfo(id: 0, content: "인증한 투두", status: .waitExamination, mediaUrl: nil, todoContent: "짧은 인증 내용"),
+            TodoInfo(id: 1, content: "인정 투두 인정 투두 인정 투두 인정 투두", status: .approve, todoContent: ""),
+            TodoInfo(id: 2, content: "노인정투두노인정투두노인정투두노인정투두", status: .reject, mediaUrl: nil, todoContent: "긴인증내용긴인증내용긴인증내용긴인증내용", rejectReason: "짧은노인정이유"),
+            TodoInfo(id: 3, content: "노인정투두노인정투두노인정투두노인정투두", status: .reject, mediaUrl: nil, todoContent: "긴인증내용긴인증내용긴인증내용긴인증내용", rejectReason: "노인정이유노인정이유노인정이유노인정이유노인정이유")
+        ]
+        
+        closeButton.action = didTapCloseButton
+        todoExaminationModalityView = ExaminationModalityView(buttonAction: { type in
+            switch type {
+            case .reject:
+                // TODO: rejectReason 초기화
+                self.closeButton.setButtonStatus(status: .disabled)
+                PopupManager.shared.showPopup(type: .rejectReason, completeAction: { rejectReason in
+                    // TODO: rejectReason 재정의
+                    self.closeButton.setButtonStatus(status: .enabled)
+                })
+                
+            case .approve:
+                self.closeButton.setButtonStatus(status: .enabled)
+                
+            default:
+                return
+            }
+        }, todoInfo: todoInfos[0])
+    }
+    
+    override func configureHierarchy() {
+        [backgroundView, titlaLabel, todoExaminationModalityView, closeButton].forEach { view.addSubview($0) }
+    }
+    
+    override func configureConstraints() {
+        backgroundView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        titlaLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(48)
+            $0.height.equalTo(36)
+        }
+        
+        todoExaminationModalityView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(48)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(50)
+        }
+    }
+    
+    private func didTapCloseButton() {
+        // TODO: 끝이 아니라면 다음으로
+        ModalityManager.shared.dismiss()
+    }
+}

--- a/dogether/Presentation/View/PopupViewController.swift
+++ b/dogether/Presentation/View/PopupViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 final class PopupViewController: BaseViewController {
     var popupType: PopupTypes?
     var todoInfo: TodoInfo?
-    var completeAction: (() -> Void)?
+    var completeAction: ((String) -> Void)?
     
     private var cameraManager: CameraManager!
     private var galleryManager: GalleryManager!
@@ -34,7 +34,7 @@ final class PopupViewController: BaseViewController {
         guard let popupType else { return }
         switch popupType {
         case .certification:
-            popupView = CertificationPopupView(completeAction: completeAction ?? { })
+            popupView = CertificationPopupView(completeAction: completeAction ?? { _ in })
             
             cameraManager = CameraManager(viewController: self)
             galleryManager = GalleryManager(viewController: self)
@@ -56,6 +56,8 @@ final class PopupViewController: BaseViewController {
         case .certificationInfo:
             guard let todoInfo else { return }
             popupView = CertificationInfoPopupView(todoInfo: todoInfo)
+        case .rejectReason:
+            popupView = RejectReasonPopupView(completeAction: completeAction ?? { _ in })
         }
     }
     

--- a/dogether/Utility/Manager/ModalityManager.swift
+++ b/dogether/Utility/Manager/ModalityManager.swift
@@ -1,0 +1,34 @@
+//
+//  ModalityManager.swift
+//  dogether
+//
+//  Created by seungyooooong on 2/17/25.
+//
+
+import Foundation
+import UIKit
+
+final class ModalityManager {
+    static let shared = ModalityManager()
+    
+    private init() { }
+    
+    var window: UIWindow?
+
+    func show() {
+        guard window == nil else { return }
+        
+        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        let newWindow = UIWindow(windowScene: windowScene!)
+        newWindow.frame = UIScreen.main.bounds
+        newWindow.windowLevel = .alert + 1
+        newWindow.rootViewController = ModalityViewController()
+        newWindow.isHidden = false
+        self.window = newWindow
+    }
+    
+    func dismiss() {
+        window?.isHidden = true
+        window = nil
+    }
+}

--- a/dogether/Utility/Manager/PopupManager.swift
+++ b/dogether/Utility/Manager/PopupManager.swift
@@ -13,12 +13,19 @@ final class PopupManager {
 
     private init() {}
 
-    func showPopup(type: PopupTypes, animated: Bool = true, completion: (() -> Void)? = nil, todoInfo: TodoInfo? = nil) {
+    func showPopup(
+        type: PopupTypes,
+        animated: Bool = true,
+        completion: (() -> Void)? = nil,
+        todoInfo: TodoInfo? = nil,
+        completeAction: ((String) -> Void)? = nil
+    ) {
         guard let currentViewController = getCurrentViewController() else { return }
 
         let popupViewController = PopupViewController()
         popupViewController.popupType = type
         popupViewController.todoInfo = todoInfo
+        popupViewController.completeAction = completeAction
         popupViewController.modalPresentationStyle = .overFullScreen
         popupViewController.modalTransitionStyle = .crossDissolve
         currentViewController.present(popupViewController, animated: animated, completion: completion)
@@ -30,11 +37,8 @@ final class PopupManager {
     }
 
     private func getCurrentViewController() -> UIViewController? {
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let window = windowScene.windows.first,
-              let rootViewController = window.rootViewController else {
-            return nil
-        }
+        guard let window = getCurrentWindow(),
+              let rootViewController = window.rootViewController else { return nil }
         
         var currentViewController = rootViewController
         while let presentedViewController = currentViewController.presentedViewController {
@@ -42,5 +46,15 @@ final class PopupManager {
         }
         
         return currentViewController
+    }
+    
+    private func getCurrentWindow() -> UIWindow? {
+        if let window = ModalityManager.shared.window {
+            return window
+        } else {
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  let window = windowScene.windows.first else { return nil }
+            return window
+        }
     }
 }


### PR DESCRIPTION
### 📝 Issue Number
- #42 

### 🔧 변경 사항
- ModalityManager를 구현했어요
- ExaminationModalityView를 추가했어요
- rejectReasonPopup를 추가했어요
- 키보드 관련 일부 내용을 수정하고 PopupManager를 수정했어요

###  🔍 변경 이유
- 투두 검사 화면은 어디서든 나타날 수 있어야하고, 제일 상위에 있어야하며, 모든 검사를 마쳐야 앱을 이용할 수 있도록 만들어야 했어요

### 🔗 참고 자료
- [Figma](https://www.figma.com/design/hy4zveKj4xCoMSeUcjJd7x/%5B%EC%B0%90%5DDND12%EA%B8%B0_1%EC%A1%B0?node-id=1009-7656&t=8Ri5XarzCWyA19Am-11)
- [HIG - Modality](https://developer.apple.com/design/human-interface-guidelines/modality)
